### PR TITLE
Update git-p4.py

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -796,7 +796,7 @@ def createOrUpdateBranchesFromOrigin(localRefPrefix = "refs/remotes/p4/", silent
         update = False
         if not gitBranchExists(remoteHead):
             if verbose:
-                print "creating %s" % remoteHead
+                print ("creating %s" % (remoteHead))
             update = True
         else:
             settings = extractSettingsGitLog(extractLogMessageFromGitCommit(remoteHead))


### PR DESCRIPTION
Adding missing parenthesis on a print statement in verbose mode.  Causing runtime error when doing a "git p4 clone //depot/main (stream) ./main" command (windows, python 3.6.5)

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
